### PR TITLE
feat: Expose the Addr value

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -78,7 +78,7 @@ lazy_static! {
 
 /// A newtype for addresses.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Addr(u64);
+pub struct Addr(pub u64);
 
 #[cfg(feature = "with_serde")]
 impl Serialize for Addr {


### PR DESCRIPTION
Exposes the value of the `Addr` type so that one can actually do something with it.