### PR TITLE
fix: Emit a specific error for binary image identifiers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -197,6 +197,7 @@ enum ParsingState {
 pub enum ParseError {
     Io(io::Error),
     InvalidIncidentIdentifier(uuid::Error),
+    InvalidImageIdentifier(uuid::Error),
     InvalidReportVersion(std::num::ParseIntError),
     InvalidTimestamp(chrono::ParseError),
 }
@@ -206,6 +207,7 @@ impl std::error::Error for ParseError {
         match *self {
             ParseError::Io(ref err) => Some(err),
             ParseError::InvalidIncidentIdentifier(ref err) => Some(err),
+            ParseError::InvalidImageIdentifier(ref err) => Some(err),
             ParseError::InvalidReportVersion(ref err) => Some(err),
             ParseError::InvalidTimestamp(ref err) => Some(err),
         }
@@ -217,6 +219,7 @@ impl fmt::Display for ParseError {
         match *self {
             ParseError::Io(..) => write!(f, "io error during parsing"),
             ParseError::InvalidIncidentIdentifier(..) => write!(f, "invalid incident identifier"),
+            ParseError::InvalidImageIdentifier(..) => write!(f, "invalid binary image identifier"),
             ParseError::InvalidReportVersion(..) => write!(f, "invalid report version"),
             ParseError::InvalidTimestamp(..) => write!(f, "invalid timestamp"),
         }
@@ -378,7 +381,7 @@ impl AppleCrashReport {
                             size: u64::from_str_radix(&caps[2][2..], 16).unwrap() - addr,
                             uuid: caps[6]
                                 .parse()
-                                .map_err(ParseError::InvalidIncidentIdentifier)?,
+                                .map_err(ParseError::InvalidImageIdentifier)?,
                             arch: caps[4].to_string(),
                             version: caps.get(5).map(|x| x.as_str().to_string()),
                             name: caps[3].to_string(),

--- a/tests/fixtures/spaces.txt
+++ b/tests/fixtures/spaces.txt
@@ -1,0 +1,37 @@
+Thread 0:
+0   App Namespace                       0x0000000102268e70 0x10211c000 + 1363568
+1   App Namespace                       0x0000000102268550 0x10211c000 + 1361232
+2   App Namespace                       0x000000010226860c 0x10211c000 + 1361420
+3   UIKitCore                           0x00000001b81d6948 0x1b7609000 + 12376392
+4   UIKitCore                           0x00000001b81d6464 0x1b7609000 + 12375140
+5   UIKitCore                           0x00000001b81d6b64 0x1b7609000 + 12376932
+6   UIKitCore                           0x00000001b8015c84 0x1b7609000 + 10538116
+7   UIKitCore                           0x00000001b80057d4 0x1b7609000 + 10471380
+8   UIKitCore                           0x00000001b8035744 0x1b7609000 + 10667844
+9   CoreFoundation                      0x00000001b3f03e68 0x1b3e5b000 + 691816
+10  CoreFoundation                      0x00000001b3efed54 0x1b3e5b000 + 671060
+11  CoreFoundation                      0x00000001b3eff320 0x1b3e5b000 + 672544
+12  CoreFoundation                      0x00000001b3efeadc 0x1b3e5b000 + 670428
+13  GraphicsServices                    0x00000001bde9f328 0x1bde9c000 + 13096
+14  UIKitCore                           0x00000001b800c63c 0x1b7609000 + 10499644
+15  App Namespace                       0x000000010212d008 0x10211c000 + 69640
+16  libdyld.dylib                       0x00000001b3d88360 0x1b3d87000 + 4960
+
+Binary Images:
+       0x10211c000 -        0x1024b3fff App Namespace arm64  <debeff4e26534f38e59bc9de7b8daade> /private/var/containers/Bundle/Application/012CABCB-BD5B-1234-AE44-3215BF57D1CD/App Namespace Some.app/App Namespace
+       0x1b3dc2000 -        0x1b3e18fff libc++.1.dylib arm64  <6bc32e62110531eebcdeab97b76d5507> /usr/lib/libc++.1.dylib
+       0x102638000 -        0x10266bfff SomeNet arm64  <0e89aabbddd33bfd90e2f2da54d3da23> /private/var/containers/Bundle/Application/012CABCB-BD5B-4881-AE44-3215BF57D1CD/App Namespace Some.app/Frameworks/some.framework/SomeNet
+       0x1b4237000 -        0x1b44f0fff Foundation arm64  <7b1733b174c93a338a58853b0a029826> /System/Library/Frameworks/Foundation.framework/Foundation
+       0x102a20000 -        0x102ca3fff SharedIOSFramework arm64  <004d54f641393bae8f166277368ff79e> /private/var/containers/Bundle/Application/012CABCB-BD5B-4881-AE44-3215BF57D1CD/App Namespace Some.app/Frameworks/SharedIOSFramework.framework/SharedIOSFramework
+       0x1b71c7000 -        0x1b7527fff CFNetwork arm64  <59b74c73dcc33a999647189b124b265b> /System/Library/Frameworks/CFNetwork.framework/CFNetwork
+       0x1c08b8000 -        0x1c0a7afff CoreMotion arm64  <86e7ee42c1f936fb9bf0af733547d042> /System/Library/Frameworks/CoreMotion.framework/CoreMotion
+       0x1b3e5b000 -        0x1b41cffff CoreFoundation arm64  <7519e99910533367b9d58844f6d3bdc6> /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
+       0x1b7609000 -        0x1b86cffff UIKitCore arm64  <d76300677a003cb799e1e7f6c55d85c5> /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore
+       0x1bde9c000 -        0x1bdea4fff GraphicsServices arm64  <cefbbc61fdb33db786bf337e511616db> /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
+       0x1c2c99000 -        0x1c39fbfff JavaScriptCore arm64  <c87fa51eb1033902a963faaedb228c86> /System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore
+       0x1b3bf7000 -        0x1b3c6bfff libdispatch.dylib arm64  <b9d95eab9269367db2f4c2b45821a32d> /usr/lib/system/libdispatch.dylib
+       0x1b3d87000 -        0x1b3db8fff libdyld.dylib arm64  <7b531a153e73318590e2b88d9476da5e> /usr/lib/system/libdyld.dylib
+       0x1b3d59000 -        0x1b3d86fff libsystem_kernel.dylib arm64  <1b7d718405d63a83bb1bf9af6aef61f3> /usr/lib/system/libsystem_kernel.dylib
+       0x1b3c97000 -        0x1b3ca7fff libsystem_pthread.dylib arm64  <1ff7a2fb9f2837b7af39344206a322bd> /usr/lib/system/libsystem_pthread.dylib
+       0x1bfe9a000 -        0x1bffe6fff WebKitLegacy arm64  <e259406b03a43977a227fcae8df2bc95> /System/Library/PrivateFrameworks/WebKitLegacy.framework/WebKitLegacy
+       0x1bbaeb000 -        0x1bd6dffff WebCore arm64  <83a4a19111a0313897dcef1313f78bae> /System/Library/PrivateFrameworks/WebCore.framework/WebCore

--- a/tests/snapshots/test_snapshots__spaces.snap
+++ b/tests/snapshots/test_snapshots__spaces.snap
@@ -1,0 +1,148 @@
+---
+source: tests/test_snapshots.rs
+expression: "&report"
+---
+incident_identifier: 00000000-0000-0000-0000-000000000000
+report_version: 0
+metadata: {}
+threads:
+  - id: 0
+    crashed: false
+    frames:
+      - module: App Namespace
+        instruction_addr: 0x102268e70
+      - module: App Namespace
+        instruction_addr: 0x102268550
+      - module: App Namespace
+        instruction_addr: 0x10226860c
+      - module: UIKitCore
+        instruction_addr: 0x1b81d6948
+      - module: UIKitCore
+        instruction_addr: 0x1b81d6464
+      - module: UIKitCore
+        instruction_addr: 0x1b81d6b64
+      - module: UIKitCore
+        instruction_addr: 0x1b8015c84
+      - module: UIKitCore
+        instruction_addr: 0x1b80057d4
+      - module: UIKitCore
+        instruction_addr: 0x1b8035744
+      - module: CoreFoundation
+        instruction_addr: 0x1b3f03e68
+      - module: CoreFoundation
+        instruction_addr: 0x1b3efed54
+      - module: CoreFoundation
+        instruction_addr: 0x1b3eff320
+      - module: CoreFoundation
+        instruction_addr: 0x1b3efeadc
+      - module: GraphicsServices
+        instruction_addr: 0x1bde9f328
+      - module: UIKitCore
+        instruction_addr: 0x1b800c63c
+      - module: App Namespace
+        instruction_addr: 0x10212d008
+      - module: libdyld.dylib
+        instruction_addr: 0x1b3d88360
+binary_images:
+  - addr: 0x10211c000
+    size: 3768319
+    uuid: debeff4e-2653-4f38-e59b-c9de7b8daade
+    arch: arm64
+    name: App Namespace
+    path: /private/var/containers/Bundle/Application/012CABCB-BD5B-1234-AE44-3215BF57D1CD/App Namespace Some.app/App Namespace
+  - addr: 0x1b3dc2000
+    size: 356351
+    uuid: 6bc32e62-1105-31ee-bcde-ab97b76d5507
+    arch: arm64
+    name: libc++.1.dylib
+    path: /usr/lib/libc++.1.dylib
+  - addr: 0x102638000
+    size: 212991
+    uuid: 0e89aabb-ddd3-3bfd-90e2-f2da54d3da23
+    arch: arm64
+    name: SomeNet
+    path: /private/var/containers/Bundle/Application/012CABCB-BD5B-4881-AE44-3215BF57D1CD/App Namespace Some.app/Frameworks/some.framework/SomeNet
+  - addr: 0x1b4237000
+    size: 2859007
+    uuid: 7b1733b1-74c9-3a33-8a58-853b0a029826
+    arch: arm64
+    name: Foundation
+    path: /System/Library/Frameworks/Foundation.framework/Foundation
+  - addr: 0x102a20000
+    size: 2637823
+    uuid: 004d54f6-4139-3bae-8f16-6277368ff79e
+    arch: arm64
+    name: SharedIOSFramework
+    path: /private/var/containers/Bundle/Application/012CABCB-BD5B-4881-AE44-3215BF57D1CD/App Namespace Some.app/Frameworks/SharedIOSFramework.framework/SharedIOSFramework
+  - addr: 0x1b71c7000
+    size: 3543039
+    uuid: 59b74c73-dcc3-3a99-9647-189b124b265b
+    arch: arm64
+    name: CFNetwork
+    path: /System/Library/Frameworks/CFNetwork.framework/CFNetwork
+  - addr: 0x1c08b8000
+    size: 1847295
+    uuid: 86e7ee42-c1f9-36fb-9bf0-af733547d042
+    arch: arm64
+    name: CoreMotion
+    path: /System/Library/Frameworks/CoreMotion.framework/CoreMotion
+  - addr: 0x1b3e5b000
+    size: 3624959
+    uuid: 7519e999-1053-3367-b9d5-8844f6d3bdc6
+    arch: arm64
+    name: CoreFoundation
+    path: /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
+  - addr: 0x1b7609000
+    size: 17592319
+    uuid: d7630067-7a00-3cb7-99e1-e7f6c55d85c5
+    arch: arm64
+    name: UIKitCore
+    path: /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore
+  - addr: 0x1bde9c000
+    size: 36863
+    uuid: cefbbc61-fdb3-3db7-86bf-337e511616db
+    arch: arm64
+    name: GraphicsServices
+    path: /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
+  - addr: 0x1c2c99000
+    size: 14036991
+    uuid: c87fa51e-b103-3902-a963-faaedb228c86
+    arch: arm64
+    name: JavaScriptCore
+    path: /System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore
+  - addr: 0x1b3bf7000
+    size: 479231
+    uuid: b9d95eab-9269-367d-b2f4-c2b45821a32d
+    arch: arm64
+    name: libdispatch.dylib
+    path: /usr/lib/system/libdispatch.dylib
+  - addr: 0x1b3d87000
+    size: 204799
+    uuid: 7b531a15-3e73-3185-90e2-b88d9476da5e
+    arch: arm64
+    name: libdyld.dylib
+    path: /usr/lib/system/libdyld.dylib
+  - addr: 0x1b3d59000
+    size: 188415
+    uuid: 1b7d7184-05d6-3a83-bb1b-f9af6aef61f3
+    arch: arm64
+    name: libsystem_kernel.dylib
+    path: /usr/lib/system/libsystem_kernel.dylib
+  - addr: 0x1b3c97000
+    size: 69631
+    uuid: 1ff7a2fb-9f28-37b7-af39-344206a322bd
+    arch: arm64
+    name: libsystem_pthread.dylib
+    path: /usr/lib/system/libsystem_pthread.dylib
+  - addr: 0x1bfe9a000
+    size: 1363967
+    uuid: e259406b-03a4-3977-a227-fcae8df2bc95
+    arch: arm64
+    name: WebKitLegacy
+    path: /System/Library/PrivateFrameworks/WebKitLegacy.framework/WebKitLegacy
+  - addr: 0x1bbaeb000
+    size: 29315071
+    uuid: 83a4a191-11a0-3138-97dc-ef1313f78bae
+    arch: arm64
+    name: WebCore
+    path: /System/Library/PrivateFrameworks/WebCore.framework/WebCore

--- a/tests/test_snapshots.rs
+++ b/tests/test_snapshots.rs
@@ -9,23 +9,23 @@ fn load_fixture(name: &str) -> String {
     fs::read_to_string(format!("tests/fixtures/{}.txt", name)).unwrap()
 }
 
-#[test]
-fn test_bruno() {
-    let fixture = load_fixture("bruno");
-    let report: AppleCrashReport = fixture.parse().unwrap();
-    insta::assert_yaml_snapshot!("bruno", &report);
+macro_rules! test_snapshots {
+    ( $( $test:ident => $fixture:literal ),+ $(,)? ) => {
+        $(
+            #[test]
+            fn $test() {
+                let fixture = load_fixture($fixture);
+                let report: AppleCrashReport = fixture.parse().unwrap();
+                insta::assert_yaml_snapshot!($fixture, &report);
+            }
+        )*
+    };
 }
 
-#[test]
-fn test_handcrafted() {
-    let fixture = load_fixture("handcrafted");
-    let report: AppleCrashReport = fixture.parse().unwrap();
-    insta::assert_yaml_snapshot!("handcrafted", &report);
-}
-
-#[test]
-fn test_xcdyoutubekit_54() {
-    let fixture = load_fixture("XCDYouTubeKit-54");
-    let report: AppleCrashReport = fixture.parse().unwrap();
-    insta::assert_yaml_snapshot!("XCDYouTubeKit-54", &report);
-}
+test_snapshots!(
+    test_bruno => "bruno",
+    test_handcrafted => "handcrafted",
+    test_xcdyoutubekit_54 => "XCDYouTubeKit-54",
+    // Regression test for #5: Spaces in image names
+    test_spaces => "spaces",
+);


### PR DESCRIPTION
Follow-up to #5: Emits a specific `InvalidImageIdentifier` error instead of the `InvalidIncidentIdentifier` error when parsing a binary image fails. 

The test file is taken from https://github.com/getsentry/symbolicator/issues/214#issuecomment-614783172 and was modified to parse (it contained invalid identifiers).