### PR TITLE
meta: Remove outdated time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ with_serde = ["uuid/serde", "chrono/serde", "serde"]
 regex = "1.1.0"
 lazy_static = "1.2.0"
 uuid = { version = "1.0.0" }
-chrono = { version = "0.4.23" }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 serde = { version = "1.0.84", features = ["derive"], package = "serde", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The `time` 0.1.45 dependency was pulled in by way of a `chrono` default feature that we don't actually use.

Part of https://github.com/getsentry/symbolicator/issues/634.